### PR TITLE
Removed trailing whitespace

### DIFF
--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -18,4 +18,4 @@ class DatabaseSeeder extends Seeder
             $u->likes()->attach($post);
         });
     }
-}  
+}


### PR DESCRIPTION
In PHP, PSR-2 Coding standards say that a closing bracket must be on a line all by itself. This is what was breaking. I didn't think it would be so picky
